### PR TITLE
Readable error message

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,10 @@ const eslint = require('eslint');
 const configTester = (ruleName, configObj, testFile) => {
   const cli = new eslint.CLIEngine({ baseConfig: configObj });
 
+  const msgToText = msg =>
+    `${msg.line},${msg.column}: ` +
+    `${msg.ruleId} - ${msg.message}`;
+
   /**
    * Check if the template is valid or not
    * all valid cases go through this
@@ -28,8 +32,10 @@ const configTester = (ruleName, configObj, testFile) => {
     assert.strictEqual(
       errorCount,
       0,
-      `Should have no errors but had ${errorCount}:\n${JSON.stringify(
-        report.results,
+      `Should have no errors but had ${errorCount}:\n${msgToText(
+        report.results.map(result =>
+          result.messages.map(msg => msgToText(msg)).join('\n'),
+        ),
       )}`,
     );
   };
@@ -48,7 +54,11 @@ const configTester = (ruleName, configObj, testFile) => {
       !actualErrorMsg.fatal,
       `A fatal parsing error occurred: ${actualErrorMsg.message}`,
     );
-    assert.strictEqual(actualErrorMsg, expectedErrorMsg);
+    assert.strictEqual(
+      actualErrorMsg,
+      expectedErrorMsg,
+      msgToText(actualErrorMsg),
+    );
   };
 
   const compareErrorMessagesToExpected = (
@@ -60,9 +70,9 @@ const configTester = (ruleName, configObj, testFile) => {
       expectedErrorMsgs.length,
       `Should have ${expectedErrorMsgs.length} error${
         expectedErrorMsgs.length === 1 ? '' : 's'
-      } but had ${actualErrorMsgs.length}: \n${JSON.stringify(
-        actualErrorMsgs,
-      )}`,
+      } but had ${actualErrorMsgs.length}: \n${actualErrorMsgs.map(msg =>
+        msgToText(msg),
+      ).join('\n')}`,
     );
     actualErrorMsgs.forEach((_, index) =>
       compareSingleErrorMessageToExpected(


### PR DESCRIPTION
Current error text is not human readable.

new error text is:

```
 Should have 5 errors but had 6:
1,11: func-names - Unexpected named function 'f'.
1,21: space-before-function-paren - Unexpected space before function parentheses.
2,19: space-before-function-paren - Missing space before function parentheses.
3,14: arrow-parens - Expected parentheses around arrow function argument.
3,19: arrow-body-style - Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.
6,3: func-call-spacing - Unexpected newline between function name and paren.
```